### PR TITLE
Made this helm chart work on Enterprise Linux nodes

### DIFF
--- a/chart/templates/daemonset.yaml
+++ b/chart/templates/daemonset.yaml
@@ -31,6 +31,12 @@ spec:
         - name: host-bin
           hostPath:
             path: {{ .Values.installer.hostBinPath }}
+        - name: host-etc
+          hostPath:
+            path: {{ .Values.installer.hostEtcPath }}
+        - name: host-usr-lib
+          hostPath:
+            path: {{ .Values.installer.hostUsrLibPath }}
       initContainers:
         - name: installer
           image: "{{ .Values.image.registry }}/{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
@@ -49,6 +55,10 @@ spec:
               mountPath: /host/etc/containerd
             - name: host-bin
               mountPath: /host/bin
+            - name: host-etc
+              mountPath: /host/etc
+            - name: host-usr-lib
+              mountPath: /host/usr/lib
       containers:
         - name: pause
           image: k8s.gcr.io/pause:3.1

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -13,6 +13,8 @@ fullnameOverride: ""
 installer:
   hostEtcContainerdPath: /etc/containerd
   hostBinPath: /usr/local/bin
+  hostEtcPath: /etc
+  hostUsrLibPath: /usr/lib
 
 podAnnotations: {}
 

--- a/image/entrypoint.sh
+++ b/image/entrypoint.sh
@@ -7,10 +7,21 @@ set -euo
 ##
 HOST_CONTAINERD_CONFIG="${HOST_CONTAINERD_CONFIG:-/host/etc/containerd/config.toml}"
 HOST_BIN="${HOST_BIN:-/host/bin}"
+HOST_ETC="${HOST_ETC:-/host/etc}"
+HOST_USR_LIB="${HOST_USR_LIB:-/host/usr/lib}"
 
 RUNTIME_CONFIG_TYPE="${RUNTIME_CONFIG_TYPE:-io.containerd.spin.v1}"
 RUNTIME_CONFIG_HANDLE="${RUNTIME_CONFIG_HANDLE:-spin}"
 RUNTIME_CONFIG_TABLE="plugins.\"io.containerd.grpc.v1.cri\".containerd.runtimes.${RUNTIME_CONFIG_HANDLE}"
+
+is_el() {
+  if [[ -f "${HOST_ETC}/os-release" ]]; then
+    echo "$(cat ${HOST_ETC}/os-release 2> /dev/null | grep ID_LIKE | grep rhel)"
+  fi
+  if [[ -f "${HOST_USR_LIB}/os-release" ]]; then
+    echo "$(cat ${HOST_USR_LIB} 2> /dev/null | grep ID_LIKE | grep rhel)"
+  fi
+}
 
 ##
 # helper functions
@@ -23,6 +34,13 @@ set_runtime_type() {
   echo "adding spin runtime '${RUNTIME_CONFIG_TYPE}' to ${HOST_CONTAINERD_CONFIG}"
   tmpfile=$(mktemp)
   toml set "${HOST_CONTAINERD_CONFIG}" "${RUNTIME_CONFIG_TABLE}.runtime_type" "${RUNTIME_CONFIG_TYPE}" > "${tmpfile}"
+  if [[ ! -z "$(is_el)" ]]; then
+    echo "You are running Enterprise Linux, setting SystemdCgroup to true"
+    second_tmpfile=$(mktemp)
+    toml set "${tmpfile}" "plugins.\"io.containerd.grpc.v1.cri\".containerd.runtimes.runc.options.SystemdCgroup" "true" > "${second_tmpfile}"
+    mv -f ${second_tmpfile} ${tmpfile}
+  fi
+
 
   # ensure the runtime_type was set
   if [ "$(get_runtime_type "${tmpfile}")" = "${RUNTIME_CONFIG_TYPE}" ]; then


### PR DESCRIPTION
Take 2 after sorting commit authorship. 

On Enterprise Linux (redhat, centos, fedora, rocky, alma, etc.) based hosts, wasm "pods" will never start (see [this](https://github.com/deislabs/containerd-wasm-shims/issues/165) ) because of some issue with container shims and this: `plugins."io.containerd.grpc.v1.cri".containerd.runtimes.runc.options.SystemdCgroup` needing to be explicitly set to `true` on EL-based systems. 

This PR adds distro-type detection for the host configuration script and will explicitly set that value to true if the host has `rhel` in its `ID_LIKE` value in either /etc/os-release or /usr/lib/os-release files.

This unfortunately means mounting the /etc and /usr/lib folder to the container, and the detection method I did is kind of hacky, but this works, at least with Docker and setting all the volume mounts and env vars defined in the helm chart.