### PR TITLE
Release v0.9

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,10 +6,14 @@ This project provides an automated method to install and configure the container
 
 The version of the container image and Helm chart directly correlates to the version of the containerd shim. For simplicity, here is a table depicting the version matrix between Spin and the containerd shim.
 
-| containerd-shim-spin-v1                                                         | Spin                                                          |
+| containerd-shim-spin-v*                                                         | Spin                                                          |
 | ------------------------------------------------------------------------------- | ------------------------------------------------------------- |
-| [v0.8.0](https://github.com/deislabs/containerd-wasm-shims/releases/tag/v0.8.0) | [v1.1.0](https://github.com/fermyon/spin/releases/tag/v1.4.0) |
-| [v0.7.0](https://github.com/deislabs/containerd-wasm-shims/releases/tag/v0.7.0) | [v1.1.0](https://github.com/fermyon/spin/releases/tag/v1.2.0) |
+| [v0.9.3](https://github.com/deislabs/containerd-wasm-shims/releases/tag/v0.9.3) | [v2.0.0](https://github.com/fermyon/spin/releases/tag/v2.0.0) |
+| [v0.9.2](https://github.com/deislabs/containerd-wasm-shims/releases/tag/v0.9.2) | [v1.5.0](https://github.com/fermyon/spin/releases/tag/v1.5.0) |
+| [v0.9.1](https://github.com/deislabs/containerd-wasm-shims/releases/tag/v0.9.1) | [v1.4.1](https://github.com/fermyon/spin/releases/tag/v1.4.1) |
+| [v0.9.0](https://github.com/deislabs/containerd-wasm-shims/releases/tag/v0.9.0) | [v1.4.1](https://github.com/fermyon/spin/releases/tag/v1.4.1) |
+| [v0.8.0](https://github.com/deislabs/containerd-wasm-shims/releases/tag/v0.8.0) | [v1.4.0](https://github.com/fermyon/spin/releases/tag/v1.4.0) |
+| [v0.7.0](https://github.com/deislabs/containerd-wasm-shims/releases/tag/v0.7.0) | [v1.2.0](https://github.com/fermyon/spin/releases/tag/v1.2.0) |
 | [v0.6.0](https://github.com/deislabs/containerd-wasm-shims/releases/tag/v0.6.0) | [v1.1.0](https://github.com/fermyon/spin/releases/tag/v1.1.0) |
 | [v0.5.1](https://github.com/deislabs/containerd-wasm-shims/releases/tag/v0.5.1) | [v1.0.0](https://github.com/fermyon/spin/releases/tag/v1.0.0) |
 
@@ -28,7 +32,7 @@ Because of these constraints, installing an additional runtime for containerd re
 This project provides a Helm chart that includes a [DaemonSet](chart/templates/daemonset.yaml) which runs an [init container](image/Dockerfile) _in privileged mode_ in order to copy the binary to the node and update the containerd config with the new runtime. This is the most generic way to install the containerd runtime shim in Kubernetes environments.
 
 ```shell
-helm install spin-containerd-shim-installer oci://ghcr.io/fermyon/charts/spin-containerd-shim-installer --version 0.1.0
+helm install spin-containerd-shim-installer oci://ghcr.io/fermyon/charts/spin-containerd-shim-installer --version 0.9.3
 ```
 
 ## Disclaimer

--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -4,12 +4,12 @@ kubeVersion: ">=1.20.0"
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.9.0
+version: 0.9.1
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "0.9.0"
+appVersion: "0.9.1"
 name: spin-containerd-shim-installer
 description: A Helm chart for installing the containerd shim for Spin on Kubernetes
 home: https://github.com/fermyon/spin-containerd-shim-installer

--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -4,12 +4,12 @@ kubeVersion: ">=1.20.0"
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.9.2
+version: 0.9.3
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "0.9.2"
+appVersion: "0.9.3"
 name: spin-containerd-shim-installer
 description: A Helm chart for installing the containerd shim for Spin on Kubernetes
 home: https://github.com/fermyon/spin-containerd-shim-installer

--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -4,12 +4,12 @@ kubeVersion: ">=1.20.0"
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.8.0
+version: 0.9.0
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "0.8.0"
+appVersion: "0.9.0"
 name: spin-containerd-shim-installer
 description: A Helm chart for installing the containerd shim for Spin on Kubernetes
 home: https://github.com/fermyon/spin-containerd-shim-installer

--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -4,12 +4,12 @@ kubeVersion: ">=1.20.0"
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.9.1
+version: 0.9.2
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "0.9.1"
+appVersion: "0.9.2"
 name: spin-containerd-shim-installer
 description: A Helm chart for installing the containerd shim for Spin on Kubernetes
 home: https://github.com/fermyon/spin-containerd-shim-installer

--- a/chart/templates/runtimeclass.yaml
+++ b/chart/templates/runtimeclass.yaml
@@ -1,5 +1,5 @@
 apiVersion: node.k8s.io/v1
 kind: RuntimeClass
 metadata:
-  name: wasmtime-spin-v1
+  name: wasmtime-spin-v2
 handler: spin

--- a/image/Dockerfile
+++ b/image/Dockerfile
@@ -5,8 +5,8 @@ RUN export DEBIAN_FRONTEND=noninteractive \
     && apt-get update -y \
     && apt-get install -y wget
 # NOTE: this binary uses the $(ARCH)-unknown-linux-musl triplet
-ARG SHIM_VERSION=0.5.1
-RUN wget -q -O - "https://github.com/deislabs/containerd-wasm-shims/releases/download/v${SHIM_VERSION}/containerd-wasm-shims-v1-linux-$(uname -m).tar.gz" | tar -xvz -f - containerd-shim-spin-v1
+ARG SHIM_VERSION=0.9.0
+RUN wget -q -O - "https://github.com/deislabs/containerd-wasm-shims/releases/download/v${SHIM_VERSION}/containerd-wasm-shims-v1-spin-linux-$(uname -m).tar.gz" | tar -xvz -f - containerd-shim-spin-v1
 
 # Download the toml CLI tool
 FROM rust:bullseye as toml-downloader

--- a/image/Dockerfile
+++ b/image/Dockerfile
@@ -5,7 +5,7 @@ RUN export DEBIAN_FRONTEND=noninteractive \
     && apt-get update -y \
     && apt-get install -y wget
 # NOTE: this binary uses the $(ARCH)-unknown-linux-musl triplet
-ARG SHIM_VERSION=0.9.1
+ARG SHIM_VERSION=0.9.2
 RUN wget -q -O - "https://github.com/deislabs/containerd-wasm-shims/releases/download/v${SHIM_VERSION}/containerd-wasm-shims-v1-spin-linux-$(uname -m).tar.gz" | tar -xvz -f - containerd-shim-spin-v1
 
 # Download the toml CLI tool

--- a/image/Dockerfile
+++ b/image/Dockerfile
@@ -5,8 +5,8 @@ RUN export DEBIAN_FRONTEND=noninteractive \
     && apt-get update -y \
     && apt-get install -y wget
 # NOTE: this binary uses the $(ARCH)-unknown-linux-musl triplet
-ARG SHIM_VERSION=0.9.2
-RUN wget -q -O - "https://github.com/deislabs/containerd-wasm-shims/releases/download/v${SHIM_VERSION}/containerd-wasm-shims-v1-spin-linux-$(uname -m).tar.gz" | tar -xvz -f - containerd-shim-spin-v1
+ARG SHIM_VERSION=0.9.3
+RUN wget -q -O - "https://github.com/deislabs/containerd-wasm-shims/releases/download/v${SHIM_VERSION}/containerd-wasm-shims-v2-spin-linux-$(uname -m).tar.gz" | tar -xvz -f - containerd-shim-spin-v2
 
 # Download the toml CLI tool
 FROM rust:bullseye as toml-downloader
@@ -19,7 +19,7 @@ FROM busybox:1.36
 WORKDIR /work
 
 COPY --from=toml-downloader /usr/local/cargo/bin/toml /usr/local/bin/toml
-COPY --from=shim-downloader /downloads/containerd-shim-spin-v1 ./containerd-shim-spin-v1
+COPY --from=shim-downloader /downloads/containerd-shim-spin-v2 ./containerd-shim-spin-v2
 
 COPY ./entrypoint.sh .
 CMD ["./entrypoint.sh"]

--- a/image/Dockerfile
+++ b/image/Dockerfile
@@ -5,7 +5,7 @@ RUN export DEBIAN_FRONTEND=noninteractive \
     && apt-get update -y \
     && apt-get install -y wget
 # NOTE: this binary uses the $(ARCH)-unknown-linux-musl triplet
-ARG SHIM_VERSION=0.9.0
+ARG SHIM_VERSION=0.9.1
 RUN wget -q -O - "https://github.com/deislabs/containerd-wasm-shims/releases/download/v${SHIM_VERSION}/containerd-wasm-shims-v1-spin-linux-$(uname -m).tar.gz" | tar -xvz -f - containerd-shim-spin-v1
 
 # Download the toml CLI tool

--- a/image/entrypoint.sh
+++ b/image/entrypoint.sh
@@ -8,7 +8,7 @@ set -euo
 HOST_CONTAINERD_CONFIG="${HOST_CONTAINERD_CONFIG:-/host/etc/containerd/config.toml}"
 HOST_BIN="${HOST_BIN:-/host/bin}"
 
-RUNTIME_CONFIG_TYPE="${RUNTIME_CONFIG_TYPE:-io.containerd.spin.v1}"
+RUNTIME_CONFIG_TYPE="${RUNTIME_CONFIG_TYPE:-io.containerd.spin.v2}"
 RUNTIME_CONFIG_HANDLE="${RUNTIME_CONFIG_HANDLE:-spin}"
 RUNTIME_CONFIG_TABLE="plugins.\"io.containerd.grpc.v1.cri\".containerd.runtimes.${RUNTIME_CONFIG_HANDLE}"
 
@@ -38,7 +38,7 @@ set_runtime_type() {
 ##
 # assertions
 ##
-if [ ! -f "./containerd-shim-spin-v1" ]; then
+if [ ! -f "./containerd-shim-spin-v2" ]; then
   echo "shim binary not found"
   exit 1
 fi
@@ -55,7 +55,7 @@ if [ ! -f "${HOST_CONTAINERD_CONFIG}" ]; then
 fi
 
 echo "copying the shim to the node's bin directory '${HOST_BIN}'"
-cp "./containerd-shim-spin-v1" "${HOST_BIN}"
+cp "./containerd-shim-spin-v2" "${HOST_BIN}"
 
 # check if the shim is already in the containerd config
 if [ "$(get_runtime_type "${HOST_CONTAINERD_CONFIG}")" = "${RUNTIME_CONFIG_TYPE}" ]; then


### PR DESCRIPTION
Contains tagged releases for shim versions:

- [v0.9.0](https://github.com/deislabs/containerd-wasm-shims/releases/tag/v0.9.0)
- [v0.9.1](https://github.com/deislabs/containerd-wasm-shims/releases/tag/v0.9.1)
- [v0.9.2](https://github.com/deislabs/containerd-wasm-shims/releases/tag/v0.9.2)
- [v0.9.3](https://github.com/deislabs/containerd-wasm-shims/releases/tag/v0.9.3)

Updates to the readme should address #10 